### PR TITLE
feat: add post `commenting` feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 build

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,13 @@
+accounts:
+  - name: alice
+    mnemonic: "slide moment original seven milk crawl help text kick fluid boring awkward doll wonder sure fragile plate grid hard next casual expire okay body"
+    coins: [ "20000token", "200000000stake" ]
+  - name: bob
+    mnemonic: "trap possible liquid elite embody host segment fantasy swim cable digital eager tiny broom burden diary earn hen grow engine pigeon fringe claim program"
+    coins: [ "20000token", "200000000stake" ]
+validator:
+  name: alice
+  staked: "100000000stake"
+faucet:
+  name: bob
+  coins: [ "20000token", "200000000stake" ]

--- a/proto/blog/v1/query.proto
+++ b/proto/blog/v1/query.proto
@@ -9,6 +9,7 @@ import "blog/v1/types.proto";
 // Query defines the gRPC querier service.
 service Query {
   rpc AllPosts(QueryAllPostsRequest) returns (QueryAllPostsResponse);
+  rpc AllComments(QueryAllCommentsRequest) returns (QueryAllCommentsResponse);
 }
 
 message QueryAllPostsRequest {
@@ -17,6 +18,15 @@ message QueryAllPostsRequest {
 
 message QueryAllPostsResponse {
   repeated Post posts = 1;
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
 
+message QueryAllCommentsRequest {
+  string post_slug = 1;
+  cosmos.base.query.v1beta1.PageRequest pagination = 2;
+}
+
+message QueryAllCommentsResponse {
+  repeated Comment comments = 1;
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }

--- a/proto/blog/v1/tx.proto
+++ b/proto/blog/v1/tx.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/regen-network/bec/x/blog";
 // Msg is the blog.v1 Msg service
 service Msg {
   rpc CreatePost(MsgCreatePost) returns (MsgCreatePostResponse);
+  rpc CreateComment(MsgCreateComment) returns (MsgCreateCommentResponse);
 }
 
 // MsgCreatePost is the Msg/CreatePost request type.
@@ -18,3 +19,14 @@ message MsgCreatePost {
 
 // MsgCreatePostResponse is the Msg/CreatePost response type.
 message MsgCreatePostResponse {}
+
+// MsgCreateComment is the Msg/CreateComment request type.
+message MsgCreateComment {
+  string author = 1;
+  string post_slug = 2;
+  string body = 3;
+}
+
+// MsgCreateCommentResponse is the Msg/CreateComment response type.
+message MsgCreateCommentResponse {
+}

--- a/proto/blog/v1/types.proto
+++ b/proto/blog/v1/types.proto
@@ -11,3 +11,9 @@ message Post {
   string title = 3;
   string body = 4;
 }
+
+message Comment {
+  string post_slug = 1;
+  string author = 2;
+  string body = 3;
+}

--- a/x/blog/client/cli/query.go
+++ b/x/blog/client/cli/query.go
@@ -1,10 +1,7 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
-
-	// "strings"
 
 	"github.com/regen-network/bec/x/blog"
 	"github.com/spf13/cobra"
@@ -36,6 +33,7 @@ func CmdAllPosts() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-post",
 		Short: "list all post",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
@@ -72,11 +70,9 @@ func CmdAllComments() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-comment [post-slug]",
 		Short: "list all comment",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsPostSlug := args[0]
-			if argsPostSlug == "" {
-				return errors.New("invalid post slug")
-			}
 
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {

--- a/x/blog/keys.go
+++ b/x/blog/keys.go
@@ -1,12 +1,35 @@
 package blog
 
+import (
+	"crypto/md5"
+)
+
 const (
 	ModuleName = "blog"
 	StoreKey   = ModuleName
 
-	PostKey = "post"
+	PostKey          = "post"
+	CommentKeyPrefix = "comment"
 )
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)
+}
+
+func CommentAllKey(postSlug string) []byte {
+	prefixBytes := []byte(CommentKeyPrefix)
+	postSlugBytes := append([]byte(postSlug), byte('/'))
+	return append(prefixBytes, postSlugBytes...)
+}
+
+func CommentKey(postSlug, author, body string) []byte {
+	key := CommentAllKey(postSlug)
+	commentBytes := append(bodyKey(author, body), byte('/'))
+	return append(key, commentBytes...)
+}
+
+func bodyKey(author, body string) []byte {
+	hasher := md5.New()
+	hasher.Write([]byte(author + body))
+	return hasher.Sum(nil)
 }

--- a/x/blog/query.pb.go
+++ b/x/blog/query.pb.go
@@ -124,34 +124,146 @@ func (m *QueryAllPostsResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+type QueryAllCommentsRequest struct {
+	PostSlug   string             `protobuf:"bytes,1,opt,name=post_slug,json=postSlug,proto3" json:"post_slug,omitempty"`
+	Pagination *query.PageRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (m *QueryAllCommentsRequest) Reset()         { *m = QueryAllCommentsRequest{} }
+func (m *QueryAllCommentsRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryAllCommentsRequest) ProtoMessage()    {}
+func (*QueryAllCommentsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_eb782a0cfb4fa324, []int{2}
+}
+func (m *QueryAllCommentsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryAllCommentsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryAllCommentsRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryAllCommentsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllCommentsRequest.Merge(m, src)
+}
+func (m *QueryAllCommentsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryAllCommentsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllCommentsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryAllCommentsRequest proto.InternalMessageInfo
+
+func (m *QueryAllCommentsRequest) GetPostSlug() string {
+	if m != nil {
+		return m.PostSlug
+	}
+	return ""
+}
+
+func (m *QueryAllCommentsRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
+type QueryAllCommentsResponse struct {
+	Comments   []*Comment          `protobuf:"bytes,1,rep,name=comments,proto3" json:"comments,omitempty"`
+	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (m *QueryAllCommentsResponse) Reset()         { *m = QueryAllCommentsResponse{} }
+func (m *QueryAllCommentsResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryAllCommentsResponse) ProtoMessage()    {}
+func (*QueryAllCommentsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_eb782a0cfb4fa324, []int{3}
+}
+func (m *QueryAllCommentsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryAllCommentsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryAllCommentsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryAllCommentsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllCommentsResponse.Merge(m, src)
+}
+func (m *QueryAllCommentsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryAllCommentsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllCommentsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryAllCommentsResponse proto.InternalMessageInfo
+
+func (m *QueryAllCommentsResponse) GetComments() []*Comment {
+	if m != nil {
+		return m.Comments
+	}
+	return nil
+}
+
+func (m *QueryAllCommentsResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*QueryAllPostsRequest)(nil), "blog.v1.QueryAllPostsRequest")
 	proto.RegisterType((*QueryAllPostsResponse)(nil), "blog.v1.QueryAllPostsResponse")
+	proto.RegisterType((*QueryAllCommentsRequest)(nil), "blog.v1.QueryAllCommentsRequest")
+	proto.RegisterType((*QueryAllCommentsResponse)(nil), "blog.v1.QueryAllCommentsResponse")
 }
 
 func init() { proto.RegisterFile("blog/v1/query.proto", fileDescriptor_eb782a0cfb4fa324) }
 
 var fileDescriptor_eb782a0cfb4fa324 = []byte{
-	// 301 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x91, 0x41, 0x4b, 0xf3, 0x30,
-	0x18, 0xc7, 0x9b, 0xf7, 0x65, 0x2a, 0x19, 0x5e, 0xa2, 0xc2, 0x28, 0x18, 0xc6, 0x06, 0x3a, 0x04,
-	0x13, 0x5a, 0xcf, 0x1e, 0xf4, 0xa0, 0x78, 0x9b, 0x3d, 0x7a, 0x10, 0x9a, 0xf2, 0x50, 0x8b, 0x5d,
-	0xd3, 0x35, 0x69, 0x75, 0x1f, 0xc0, 0xbb, 0x1f, 0xcb, 0xe3, 0x8e, 0x1e, 0xa5, 0xfd, 0x22, 0x92,
-	0xa6, 0xce, 0x29, 0x8a, 0xd7, 0xe7, 0x79, 0xfe, 0xff, 0xdf, 0xaf, 0x0d, 0xde, 0x11, 0xa9, 0x8c,
-	0x79, 0xe5, 0xf1, 0x79, 0x09, 0xc5, 0x82, 0xe5, 0x85, 0xd4, 0x92, 0x6c, 0x9a, 0x21, 0xab, 0x3c,
-	0xf7, 0x28, 0x92, 0x6a, 0x26, 0x15, 0x17, 0xa1, 0x02, 0x7b, 0xc1, 0x2b, 0x4f, 0x80, 0x0e, 0x3d,
-	0x9e, 0x87, 0x71, 0x92, 0x85, 0x3a, 0x91, 0x99, 0x0d, 0xb9, 0xab, 0x26, 0xbd, 0xc8, 0x41, 0xd9,
-	0xe1, 0xe8, 0x16, 0xef, 0x5e, 0x9b, 0xd8, 0x59, 0x9a, 0x4e, 0xa5, 0xd2, 0x2a, 0x80, 0x79, 0x09,
-	0x4a, 0x93, 0x0b, 0x8c, 0x3f, 0x0b, 0x06, 0x68, 0x88, 0x26, 0x7d, 0xff, 0x80, 0x59, 0x1a, 0x33,
-	0x34, 0x66, 0x7d, 0x3a, 0x1a, 0x9b, 0x86, 0x31, 0x74, 0xd9, 0x60, 0x2d, 0x39, 0x7a, 0x42, 0x78,
-	0xef, 0x1b, 0x40, 0xe5, 0x32, 0x53, 0x40, 0xc6, 0xb8, 0x97, 0x9b, 0xc1, 0x00, 0x0d, 0xff, 0x4f,
-	0xfa, 0xfe, 0x36, 0xeb, 0xbe, 0x89, 0x99, 0xb3, 0xc0, 0xee, 0xc8, 0xe5, 0x17, 0x8d, 0x7f, 0xad,
-	0xc6, 0xe1, 0x9f, 0x1a, 0x96, 0xb0, 0xee, 0xe1, 0x07, 0xb8, 0xd7, 0x6a, 0x90, 0x2b, 0xbc, 0xf5,
-	0xa1, 0x42, 0xf6, 0x57, 0xcc, 0x9f, 0xfe, 0x81, 0x4b, 0x7f, 0x5b, 0xdb, 0xfe, 0xf3, 0xd3, 0x97,
-	0x9a, 0xa2, 0x65, 0x4d, 0xd1, 0x5b, 0x4d, 0xd1, 0x73, 0x43, 0x9d, 0x65, 0x43, 0x9d, 0xd7, 0x86,
-	0x3a, 0x37, 0xe3, 0x38, 0xd1, 0x77, 0xa5, 0x60, 0x91, 0x9c, 0xf1, 0x02, 0x62, 0xc8, 0x8e, 0x33,
-	0xd0, 0x0f, 0xb2, 0xb8, 0xe7, 0x02, 0x22, 0xfe, 0xc8, 0x4d, 0xaf, 0xd8, 0x68, 0x5f, 0xe0, 0xe4,
-	0x3d, 0x00, 0x00, 0xff, 0xff, 0x83, 0x3d, 0x41, 0xc5, 0xe2, 0x01, 0x00, 0x00,
+	// 385 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x52, 0xcb, 0x4a, 0xf3, 0x40,
+	0x14, 0xee, 0xf4, 0xa7, 0xbf, 0xed, 0x14, 0x41, 0xa2, 0x62, 0x89, 0x18, 0x6a, 0x0b, 0x5a, 0x44,
+	0x67, 0x48, 0x5d, 0xbb, 0x50, 0x41, 0x71, 0x57, 0xe3, 0xce, 0x85, 0x92, 0x84, 0x21, 0x16, 0x93,
+	0x4c, 0x9a, 0x99, 0x54, 0xbb, 0x71, 0xe7, 0x5e, 0x5f, 0xc2, 0x67, 0x71, 0xd9, 0xa5, 0x4b, 0x69,
+	0x5f, 0x44, 0x26, 0x33, 0x4d, 0x6f, 0x5e, 0x40, 0xdc, 0x7e, 0xf3, 0x9d, 0xf3, 0x5d, 0xe6, 0xc0,
+	0x65, 0xc7, 0xa7, 0x1e, 0xee, 0x9a, 0xb8, 0x93, 0x90, 0xb8, 0x87, 0xa2, 0x98, 0x72, 0xaa, 0x2d,
+	0x08, 0x10, 0x75, 0x4d, 0x7d, 0xc7, 0xa5, 0x2c, 0xa0, 0x0c, 0x3b, 0x36, 0x23, 0x92, 0x81, 0xbb,
+	0xa6, 0x43, 0xb8, 0x6d, 0xe2, 0xc8, 0xf6, 0xda, 0xa1, 0xcd, 0xdb, 0x34, 0x94, 0x43, 0x7a, 0xb6,
+	0x89, 0xf7, 0x22, 0xc2, 0x24, 0x58, 0xbb, 0x82, 0x2b, 0xe7, 0x62, 0xec, 0xd0, 0xf7, 0x5b, 0x94,
+	0x71, 0x66, 0x91, 0x4e, 0x42, 0x18, 0xd7, 0x4e, 0x20, 0x1c, 0x2f, 0xa8, 0x80, 0x2a, 0x68, 0x94,
+	0x9b, 0x5b, 0x48, 0xaa, 0x21, 0xa1, 0x86, 0xa4, 0x1f, 0xa5, 0x86, 0x5a, 0xb6, 0x47, 0xd4, 0xac,
+	0x35, 0x31, 0x59, 0x7b, 0x04, 0x70, 0x75, 0x46, 0x80, 0x45, 0x34, 0x64, 0x44, 0xab, 0xc3, 0x42,
+	0x24, 0x80, 0x0a, 0xa8, 0xfe, 0x6b, 0x94, 0x9b, 0x8b, 0x48, 0x65, 0x42, 0x82, 0x66, 0xc9, 0x37,
+	0xed, 0x74, 0xca, 0x46, 0x3e, 0xb5, 0xb1, 0xfd, 0xa3, 0x0d, 0xa9, 0x30, 0xe5, 0xe3, 0x01, 0xae,
+	0x8d, 0x6c, 0x1c, 0xd3, 0x20, 0x20, 0xe1, 0x38, 0xea, 0x3a, 0x2c, 0x09, 0xb1, 0x6b, 0xe6, 0x27,
+	0x5e, 0x9a, 0xb4, 0x64, 0x15, 0x05, 0x70, 0xe1, 0x27, 0xde, 0x4c, 0x0f, 0xf9, 0x5f, 0xf7, 0xf0,
+	0x0c, 0x60, 0x65, 0xde, 0x80, 0xaa, 0x62, 0x17, 0x16, 0x5d, 0x85, 0xa9, 0x36, 0x96, 0xb2, 0x36,
+	0x14, 0xd9, 0xca, 0x18, 0x7f, 0xd6, 0x49, 0xf3, 0x05, 0xc0, 0x42, 0xea, 0x49, 0x3b, 0x83, 0xc5,
+	0xd1, 0xff, 0x68, 0x1b, 0x99, 0xf4, 0x67, 0x87, 0xa1, 0x1b, 0x5f, 0x3d, 0xab, 0x2c, 0x16, 0x2c,
+	0x4f, 0x44, 0xd4, 0xaa, 0x73, 0xf4, 0x99, 0xfa, 0xf5, 0xcd, 0x6f, 0x18, 0x72, 0xe7, 0xd1, 0xc1,
+	0xeb, 0xc0, 0x00, 0xfd, 0x81, 0x01, 0xde, 0x07, 0x06, 0x78, 0x1a, 0x1a, 0xb9, 0xfe, 0xd0, 0xc8,
+	0xbd, 0x0d, 0x8d, 0xdc, 0x65, 0xdd, 0x6b, 0xf3, 0x9b, 0xc4, 0x41, 0x2e, 0x0d, 0x70, 0x4c, 0x3c,
+	0x12, 0xee, 0x85, 0x84, 0xdf, 0xd1, 0xf8, 0x16, 0x3b, 0xc4, 0xc5, 0xf7, 0x58, 0xac, 0x76, 0xfe,
+	0xa7, 0xa7, 0xbe, 0xff, 0x11, 0x00, 0x00, 0xff, 0xff, 0x5c, 0x21, 0x0c, 0xcd, 0x4b, 0x03, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -167,6 +279,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type QueryClient interface {
 	AllPosts(ctx context.Context, in *QueryAllPostsRequest, opts ...grpc.CallOption) (*QueryAllPostsResponse, error)
+	AllComments(ctx context.Context, in *QueryAllCommentsRequest, opts ...grpc.CallOption) (*QueryAllCommentsResponse, error)
 }
 
 type queryClient struct {
@@ -186,9 +299,19 @@ func (c *queryClient) AllPosts(ctx context.Context, in *QueryAllPostsRequest, op
 	return out, nil
 }
 
+func (c *queryClient) AllComments(ctx context.Context, in *QueryAllCommentsRequest, opts ...grpc.CallOption) (*QueryAllCommentsResponse, error) {
+	out := new(QueryAllCommentsResponse)
+	err := c.cc.Invoke(ctx, "/blog.v1.Query/AllComments", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	AllPosts(context.Context, *QueryAllPostsRequest) (*QueryAllPostsResponse, error)
+	AllComments(context.Context, *QueryAllCommentsRequest) (*QueryAllCommentsResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -197,6 +320,9 @@ type UnimplementedQueryServer struct {
 
 func (*UnimplementedQueryServer) AllPosts(ctx context.Context, req *QueryAllPostsRequest) (*QueryAllPostsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AllPosts not implemented")
+}
+func (*UnimplementedQueryServer) AllComments(ctx context.Context, req *QueryAllCommentsRequest) (*QueryAllCommentsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AllComments not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -221,6 +347,24 @@ func _Query_AllPosts_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_AllComments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAllCommentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).AllComments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/blog.v1.Query/AllComments",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).AllComments(ctx, req.(*QueryAllCommentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "blog.v1.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -228,6 +372,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AllPosts",
 			Handler:    _Query_AllPosts_Handler,
+		},
+		{
+			MethodName: "AllComments",
+			Handler:    _Query_AllComments_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -318,6 +466,97 @@ func (m *QueryAllPostsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryAllCommentsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryAllCommentsRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryAllCommentsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.PostSlug) > 0 {
+		i -= len(m.PostSlug)
+		copy(dAtA[i:], m.PostSlug)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.PostSlug)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryAllCommentsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryAllCommentsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryAllCommentsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Comments) > 0 {
+		for iNdEx := len(m.Comments) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Comments[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -350,6 +589,42 @@ func (m *QueryAllPostsResponse) Size() (n int) {
 	_ = l
 	if len(m.Posts) > 0 {
 		for _, e := range m.Posts {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryAllCommentsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.PostSlug)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryAllCommentsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Comments) > 0 {
+		for _, e := range m.Comments {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
@@ -516,6 +791,250 @@ func (m *QueryAllPostsResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Posts = append(m.Posts, &Post{})
 			if err := m.Posts[len(m.Posts)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryAllCommentsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryAllCommentsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryAllCommentsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PostSlug", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PostSlug = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryAllCommentsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryAllCommentsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryAllCommentsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Comments", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Comments = append(m.Comments, &Comment{})
+			if err := m.Comments[len(m.Comments)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/blog/requests.go
+++ b/x/blog/requests.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	_ sdk.Msg = &MsgCreatePost{}
+	_ sdk.Msg = &MsgCreateComment{}
 )
 
 func (m *MsgCreatePost) ValidateBasic() error {
@@ -27,6 +28,28 @@ func (m *MsgCreatePost) ValidateBasic() error {
 }
 
 func (m *MsgCreatePost) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(m.Author)
+	if err != nil {
+		panic(err)
+	}
+
+	return []sdk.AccAddress{addr}
+}
+
+func (m *MsgCreateComment) ValidateBasic() error {
+	if m.Author == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "no author")
+	}
+	if m.PostSlug == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "no slug")
+	}
+	if m.Body == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "no body")
+	}
+	return nil
+}
+
+func (m *MsgCreateComment) GetSigners() []sdk.AccAddress {
 	addr, err := sdk.AccAddressFromBech32(m.Author)
 	if err != nil {
 		panic(err)

--- a/x/blog/server/query_server.go
+++ b/x/blog/server/query_server.go
@@ -33,3 +33,27 @@ func (s serverImpl) AllPosts(goCtx context.Context, request *blog.QueryAllPostsR
 		Posts: posts,
 	}, nil
 }
+
+func (s serverImpl) AllComments(goCtx context.Context, request *blog.QueryAllCommentsRequest) (*blog.QueryAllCommentsResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	store := ctx.KVStore(s.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, blog.CommentAllKey(request.PostSlug))
+
+	defer iterator.Close()
+
+	var comments []*blog.Comment
+	for ; iterator.Valid(); iterator.Next() {
+		var msg blog.Comment
+		err := s.cdc.Unmarshal(iterator.Value(), &msg)
+		if err != nil {
+			return nil, err
+		}
+
+		comments = append(comments, &msg)
+	}
+
+	return &blog.QueryAllCommentsResponse{
+		Comments: comments,
+	}, nil
+}

--- a/x/blog/tx.pb.go
+++ b/x/blog/tx.pb.go
@@ -133,30 +133,134 @@ func (m *MsgCreatePostResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgCreatePostResponse proto.InternalMessageInfo
 
+// MsgCreateComment is the Msg/CreateComment request type.
+type MsgCreateComment struct {
+	Author   string `protobuf:"bytes,1,opt,name=author,proto3" json:"author,omitempty"`
+	PostSlug string `protobuf:"bytes,2,opt,name=post_slug,json=postSlug,proto3" json:"post_slug,omitempty"`
+	Body     string `protobuf:"bytes,3,opt,name=body,proto3" json:"body,omitempty"`
+}
+
+func (m *MsgCreateComment) Reset()         { *m = MsgCreateComment{} }
+func (m *MsgCreateComment) String() string { return proto.CompactTextString(m) }
+func (*MsgCreateComment) ProtoMessage()    {}
+func (*MsgCreateComment) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f15df8808566170d, []int{2}
+}
+func (m *MsgCreateComment) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgCreateComment) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgCreateComment.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgCreateComment) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCreateComment.Merge(m, src)
+}
+func (m *MsgCreateComment) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgCreateComment) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCreateComment.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgCreateComment proto.InternalMessageInfo
+
+func (m *MsgCreateComment) GetAuthor() string {
+	if m != nil {
+		return m.Author
+	}
+	return ""
+}
+
+func (m *MsgCreateComment) GetPostSlug() string {
+	if m != nil {
+		return m.PostSlug
+	}
+	return ""
+}
+
+func (m *MsgCreateComment) GetBody() string {
+	if m != nil {
+		return m.Body
+	}
+	return ""
+}
+
+// MsgCreateCommentResponse is the Msg/CreateComment response type.
+type MsgCreateCommentResponse struct {
+}
+
+func (m *MsgCreateCommentResponse) Reset()         { *m = MsgCreateCommentResponse{} }
+func (m *MsgCreateCommentResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgCreateCommentResponse) ProtoMessage()    {}
+func (*MsgCreateCommentResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f15df8808566170d, []int{3}
+}
+func (m *MsgCreateCommentResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgCreateCommentResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgCreateCommentResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgCreateCommentResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCreateCommentResponse.Merge(m, src)
+}
+func (m *MsgCreateCommentResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgCreateCommentResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCreateCommentResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgCreateCommentResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgCreatePost)(nil), "blog.v1.MsgCreatePost")
 	proto.RegisterType((*MsgCreatePostResponse)(nil), "blog.v1.MsgCreatePostResponse")
+	proto.RegisterType((*MsgCreateComment)(nil), "blog.v1.MsgCreateComment")
+	proto.RegisterType((*MsgCreateCommentResponse)(nil), "blog.v1.MsgCreateCommentResponse")
 }
 
 func init() { proto.RegisterFile("blog/v1/tx.proto", fileDescriptor_f15df8808566170d) }
 
 var fileDescriptor_f15df8808566170d = []byte{
-	// 234 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x48, 0xca, 0xc9, 0x4f,
-	0xd7, 0x2f, 0x33, 0xd4, 0x2f, 0xa9, 0xd0, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x07, 0x89,
-	0xe8, 0x95, 0x19, 0x2a, 0xa5, 0x72, 0xf1, 0xfa, 0x16, 0xa7, 0x3b, 0x17, 0xa5, 0x26, 0x96, 0xa4,
-	0x06, 0xe4, 0x17, 0x97, 0x08, 0x09, 0x71, 0xb1, 0x14, 0xe7, 0x94, 0xa6, 0x4b, 0x30, 0x2a, 0x30,
-	0x6a, 0x70, 0x06, 0x81, 0xd9, 0x42, 0x62, 0x5c, 0x6c, 0x89, 0xa5, 0x25, 0x19, 0xf9, 0x45, 0x12,
-	0x4c, 0x60, 0x51, 0x28, 0x4f, 0x48, 0x84, 0x8b, 0xb5, 0x24, 0xb3, 0x24, 0x27, 0x55, 0x82, 0x19,
-	0x2c, 0x0c, 0xe1, 0x80, 0x4c, 0x48, 0xca, 0x4f, 0xa9, 0x94, 0x60, 0x81, 0x98, 0x00, 0x62, 0x2b,
-	0x89, 0x73, 0x89, 0xa2, 0x58, 0x13, 0x94, 0x5a, 0x5c, 0x90, 0x9f, 0x57, 0x9c, 0x6a, 0xe4, 0xcd,
-	0xc5, 0xec, 0x5b, 0x9c, 0x2e, 0xe4, 0xc2, 0xc5, 0x85, 0xe4, 0x06, 0x31, 0x3d, 0xa8, 0xf3, 0xf4,
-	0x50, 0x34, 0x49, 0xc9, 0x61, 0x17, 0x87, 0x19, 0xe6, 0x64, 0x7b, 0xe2, 0x91, 0x1c, 0xe3, 0x85,
-	0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0x4e, 0x78, 0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3,
-	0x8d, 0xc7, 0x72, 0x0c, 0x51, 0xca, 0xe9, 0x99, 0x25, 0x19, 0xa5, 0x49, 0x7a, 0xc9, 0xf9, 0xb9,
-	0xfa, 0x45, 0xa9, 0xe9, 0xa9, 0x79, 0xba, 0x79, 0xa9, 0x25, 0xe5, 0xf9, 0x45, 0xd9, 0xfa, 0x49,
-	0xa9, 0xc9, 0xfa, 0x15, 0xfa, 0x20, 0x73, 0x93, 0xd8, 0xc0, 0x61, 0x63, 0x0c, 0x08, 0x00, 0x00,
-	0xff, 0xff, 0x86, 0x8e, 0xc6, 0xb8, 0x2f, 0x01, 0x00, 0x00,
+	// 302 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0xbd, 0x4e, 0xc3, 0x30,
+	0x14, 0x85, 0x63, 0x52, 0x0a, 0xbd, 0x52, 0xa5, 0xca, 0x82, 0x12, 0x82, 0x64, 0x41, 0x58, 0x58,
+	0x88, 0x55, 0x98, 0x59, 0x28, 0x6b, 0x24, 0x54, 0x36, 0x18, 0x50, 0x53, 0x2c, 0xb7, 0x22, 0x89,
+	0xa3, 0xd8, 0x29, 0xe5, 0x2d, 0x98, 0x79, 0x22, 0xc6, 0x8e, 0x8c, 0x28, 0x79, 0x11, 0xe4, 0xfc,
+	0xa0, 0x04, 0xe8, 0x76, 0xef, 0x39, 0xca, 0xf9, 0xce, 0x8d, 0x61, 0xe0, 0x07, 0x82, 0xd3, 0xe5,
+	0x88, 0xaa, 0x95, 0x1b, 0x27, 0x42, 0x09, 0xbc, 0xa3, 0x15, 0x77, 0x39, 0x72, 0x18, 0xf4, 0x3d,
+	0xc9, 0xc7, 0x09, 0x9b, 0x2a, 0x76, 0x2b, 0xa4, 0xc2, 0x18, 0x3a, 0x32, 0x48, 0xb9, 0x85, 0x8e,
+	0xd1, 0x59, 0x6f, 0x52, 0xcc, 0x78, 0x08, 0xdd, 0x69, 0xaa, 0xe6, 0x22, 0xb1, 0xb6, 0x0a, 0xb5,
+	0xda, 0xf0, 0x1e, 0x6c, 0xab, 0x85, 0x0a, 0x98, 0x65, 0x16, 0x72, 0xb9, 0xe8, 0x04, 0x5f, 0x3c,
+	0xbd, 0x5a, 0x9d, 0x32, 0x41, 0xcf, 0xce, 0x01, 0xec, 0xb7, 0x30, 0x13, 0x26, 0x63, 0x11, 0x49,
+	0xe6, 0x3c, 0xc0, 0xe0, 0xc7, 0x18, 0x8b, 0x30, 0x64, 0x91, 0x6a, 0xe0, 0x50, 0x0b, 0x77, 0x04,
+	0xbd, 0x58, 0x48, 0xf5, 0x58, 0xf4, 0x2b, 0x9b, 0xec, 0x6a, 0xe1, 0x4e, 0x77, 0xac, 0xa9, 0x66,
+	0x83, 0x6a, 0x83, 0xf5, 0x3b, 0xbc, 0x06, 0x5f, 0xbc, 0x23, 0x30, 0x3d, 0xc9, 0xf1, 0x0d, 0x40,
+	0xe3, 0xfa, 0xa1, 0x5b, 0xfd, 0x18, 0xb7, 0x55, 0xd7, 0x26, 0xff, 0xeb, 0x75, 0x1a, 0xf6, 0xa0,
+	0xdf, 0xbe, 0xe1, 0xf0, 0xef, 0x07, 0x95, 0x65, 0x9f, 0x6c, 0xb4, 0xea, 0xb8, 0xeb, 0xab, 0x8f,
+	0x8c, 0xa0, 0x75, 0x46, 0xd0, 0x57, 0x46, 0xd0, 0x5b, 0x4e, 0x8c, 0x75, 0x4e, 0x8c, 0xcf, 0x9c,
+	0x18, 0xf7, 0xa7, 0x7c, 0xa1, 0xe6, 0xa9, 0xef, 0xce, 0x44, 0x48, 0x13, 0xc6, 0x59, 0x74, 0x1e,
+	0x31, 0xf5, 0x22, 0x92, 0x67, 0xea, 0xb3, 0x19, 0x5d, 0x51, 0x1d, 0xed, 0x77, 0x8b, 0x47, 0xbe,
+	0xfc, 0x0e, 0x00, 0x00, 0xff, 0xff, 0x13, 0x37, 0xa5, 0x5c, 0xf8, 0x01, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -172,6 +276,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
 	CreatePost(ctx context.Context, in *MsgCreatePost, opts ...grpc.CallOption) (*MsgCreatePostResponse, error)
+	CreateComment(ctx context.Context, in *MsgCreateComment, opts ...grpc.CallOption) (*MsgCreateCommentResponse, error)
 }
 
 type msgClient struct {
@@ -191,9 +296,19 @@ func (c *msgClient) CreatePost(ctx context.Context, in *MsgCreatePost, opts ...g
 	return out, nil
 }
 
+func (c *msgClient) CreateComment(ctx context.Context, in *MsgCreateComment, opts ...grpc.CallOption) (*MsgCreateCommentResponse, error) {
+	out := new(MsgCreateCommentResponse)
+	err := c.cc.Invoke(ctx, "/blog.v1.Msg/CreateComment", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	CreatePost(context.Context, *MsgCreatePost) (*MsgCreatePostResponse, error)
+	CreateComment(context.Context, *MsgCreateComment) (*MsgCreateCommentResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -202,6 +317,9 @@ type UnimplementedMsgServer struct {
 
 func (*UnimplementedMsgServer) CreatePost(ctx context.Context, req *MsgCreatePost) (*MsgCreatePostResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreatePost not implemented")
+}
+func (*UnimplementedMsgServer) CreateComment(ctx context.Context, req *MsgCreateComment) (*MsgCreateCommentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateComment not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -226,6 +344,24 @@ func _Msg_CreatePost_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_CreateComment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgCreateComment)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).CreateComment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/blog.v1.Msg/CreateComment",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).CreateComment(ctx, req.(*MsgCreateComment))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "blog.v1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -233,6 +369,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreatePost",
 			Handler:    _Msg_CreatePost_Handler,
+		},
+		{
+			MethodName: "CreateComment",
+			Handler:    _Msg_CreateComment_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -313,6 +453,73 @@ func (m *MsgCreatePostResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgCreateComment) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgCreateComment) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgCreateComment) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Body) > 0 {
+		i -= len(m.Body)
+		copy(dAtA[i:], m.Body)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Body)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.PostSlug) > 0 {
+		i -= len(m.PostSlug)
+		copy(dAtA[i:], m.PostSlug)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.PostSlug)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Author) > 0 {
+		i -= len(m.Author)
+		copy(dAtA[i:], m.Author)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Author)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgCreateCommentResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgCreateCommentResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgCreateCommentResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -350,6 +557,36 @@ func (m *MsgCreatePost) Size() (n int) {
 }
 
 func (m *MsgCreatePostResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgCreateComment) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Author)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.PostSlug)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Body)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgCreateCommentResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -572,6 +809,208 @@ func (m *MsgCreatePostResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgCreatePostResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgCreateComment) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgCreateComment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgCreateComment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Author", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Author = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PostSlug", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PostSlug = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Body", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Body = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgCreateCommentResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgCreateCommentResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgCreateCommentResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/x/blog/types.pb.go
+++ b/x/blog/types.pb.go
@@ -92,26 +92,89 @@ func (m *Post) GetBody() string {
 	return ""
 }
 
+type Comment struct {
+	PostSlug string `protobuf:"bytes,1,opt,name=post_slug,json=postSlug,proto3" json:"post_slug,omitempty"`
+	Author   string `protobuf:"bytes,2,opt,name=author,proto3" json:"author,omitempty"`
+	Body     string `protobuf:"bytes,3,opt,name=body,proto3" json:"body,omitempty"`
+}
+
+func (m *Comment) Reset()         { *m = Comment{} }
+func (m *Comment) String() string { return proto.CompactTextString(m) }
+func (*Comment) ProtoMessage()    {}
+func (*Comment) Descriptor() ([]byte, []int) {
+	return fileDescriptor_73573037ee301d2b, []int{1}
+}
+func (m *Comment) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Comment) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Comment.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Comment) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Comment.Merge(m, src)
+}
+func (m *Comment) XXX_Size() int {
+	return m.Size()
+}
+func (m *Comment) XXX_DiscardUnknown() {
+	xxx_messageInfo_Comment.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Comment proto.InternalMessageInfo
+
+func (m *Comment) GetPostSlug() string {
+	if m != nil {
+		return m.PostSlug
+	}
+	return ""
+}
+
+func (m *Comment) GetAuthor() string {
+	if m != nil {
+		return m.Author
+	}
+	return ""
+}
+
+func (m *Comment) GetBody() string {
+	if m != nil {
+		return m.Body
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*Post)(nil), "blog.v1.Post")
+	proto.RegisterType((*Comment)(nil), "blog.v1.Comment")
 }
 
 func init() { proto.RegisterFile("blog/v1/types.proto", fileDescriptor_73573037ee301d2b) }
 
 var fileDescriptor_73573037ee301d2b = []byte{
-	// 187 bytes of a gzipped FileDescriptorProto
+	// 221 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4e, 0xca, 0xc9, 0x4f,
 	0xd7, 0x2f, 0x33, 0xd4, 0x2f, 0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,
 	0x62, 0x07, 0x09, 0xea, 0x95, 0x19, 0x2a, 0xc5, 0x70, 0xb1, 0x04, 0xe4, 0x17, 0x97, 0x08, 0x09,
 	0x71, 0xb1, 0x14, 0xe7, 0x94, 0xa6, 0x4b, 0x30, 0x2a, 0x30, 0x6a, 0x70, 0x06, 0x81, 0xd9, 0x42,
 	0x62, 0x5c, 0x6c, 0x89, 0xa5, 0x25, 0x19, 0xf9, 0x45, 0x12, 0x4c, 0x60, 0x51, 0x28, 0x4f, 0x48,
 	0x84, 0x8b, 0xb5, 0x24, 0xb3, 0x24, 0x27, 0x55, 0x82, 0x19, 0x2c, 0x0c, 0xe1, 0x80, 0x4c, 0x48,
-	0xca, 0x4f, 0xa9, 0x94, 0x60, 0x81, 0x98, 0x00, 0x62, 0x3b, 0xd9, 0x9e, 0x78, 0x24, 0xc7, 0x78,
-	0xe1, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x8c, 0x13, 0x1e, 0xcb, 0x31, 0x5c, 0x78, 0x2c, 0xc7,
-	0x70, 0xe3, 0xb1, 0x1c, 0x43, 0x94, 0x72, 0x7a, 0x66, 0x49, 0x46, 0x69, 0x92, 0x5e, 0x72, 0x7e,
-	0xae, 0x7e, 0x51, 0x6a, 0x7a, 0x6a, 0x9e, 0x6e, 0x5e, 0x6a, 0x49, 0x79, 0x7e, 0x51, 0xb6, 0x7e,
-	0x52, 0x6a, 0xb2, 0x7e, 0x85, 0x3e, 0xc8, 0x7d, 0x49, 0x6c, 0x60, 0xc7, 0x1a, 0x03, 0x02, 0x00,
-	0x00, 0xff, 0xff, 0xf7, 0xa2, 0x98, 0xf3, 0xc3, 0x00, 0x00, 0x00,
+	0xca, 0x4f, 0xa9, 0x94, 0x60, 0x81, 0x98, 0x00, 0x62, 0x2b, 0x05, 0x71, 0xb1, 0x3b, 0xe7, 0xe7,
+	0xe6, 0xa6, 0xe6, 0x95, 0x08, 0x49, 0x73, 0x71, 0x16, 0xe4, 0x17, 0x97, 0xc4, 0x23, 0xd9, 0xc2,
+	0x01, 0x12, 0x08, 0xc6, 0x67, 0x13, 0xcc, 0x4c, 0x66, 0x84, 0x99, 0x4e, 0xb6, 0x27, 0x1e, 0xc9,
+	0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17, 0x1e,
+	0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0xa5, 0x9c, 0x9e, 0x59, 0x92, 0x51, 0x9a, 0xa4, 0x97,
+	0x9c, 0x9f, 0xab, 0x5f, 0x94, 0x9a, 0x9e, 0x9a, 0xa7, 0x9b, 0x97, 0x5a, 0x52, 0x9e, 0x5f, 0x94,
+	0xad, 0x9f, 0x94, 0x9a, 0xac, 0x5f, 0xa1, 0x0f, 0xf2, 0x73, 0x12, 0x1b, 0x38, 0x00, 0x8c, 0x01,
+	0x01, 0x00, 0x00, 0xff, 0xff, 0x2e, 0x95, 0xe9, 0x93, 0x17, 0x01, 0x00, 0x00,
 }
 
 func (m *Post) Marshal() (dAtA []byte, err error) {
@@ -165,6 +228,50 @@ func (m *Post) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Comment) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Comment) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Comment) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Body) > 0 {
+		i -= len(m.Body)
+		copy(dAtA[i:], m.Body)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.Body)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Author) > 0 {
+		i -= len(m.Author)
+		copy(dAtA[i:], m.Author)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.Author)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.PostSlug) > 0 {
+		i -= len(m.PostSlug)
+		copy(dAtA[i:], m.PostSlug)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.PostSlug)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -191,6 +298,27 @@ func (m *Post) Size() (n int) {
 		n += 1 + l + sovTypes(uint64(l))
 	}
 	l = len(m.Title)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	l = len(m.Body)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
+func (m *Comment) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.PostSlug)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	l = len(m.Author)
 	if l > 0 {
 		n += 1 + l + sovTypes(uint64(l))
 	}
@@ -333,6 +461,155 @@ func (m *Post) Unmarshal(dAtA []byte) error {
 			m.Title = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Body", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Body = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Comment) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Comment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Comment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PostSlug", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PostSlug = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Author", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Author = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Body", wireType)
 			}


### PR DESCRIPTION
## Description

add post `commenting` feature to the `x/blog` moduleL

- Add a new `Msg` service method called `CreateComment`. This method's input takes:
  - `post_slug` as string,
  - `author` as string (Bech32-encoded address),
  - `body` as a string.
- New comments are persisted in the blockchain state. Comment cannot be inserted into the state if its corresponding `Post` does not exist in the state.
- Add a new `AllComments` gRPC query method. This method's input should take a `post_slug` (a string) and returns all the comments on a post.
- Add CLI subcommands, `tx create-comment` and `query list-comments`, which call the `CreateComment` and `AllComments` service methods under the hood.

## Aditional features

- A comment cannot be duplicated by the same user to avoid flooding the posts or the network.
- Add `config.yml` for we can run the chain using ignite (eg: `ignite c serve`); 

### How to test

#### Run the chain:

- Using the Makefile:
```shell
$ make build
```

- Using the [Ignite CLI](https://github.com/ignite/cli/pulls)
```shell
$ ignite c serve
```

#### Test Commands:

- Create posts:
```shell
$ becd tx blog create-post cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug1 title1 body1 --chain-id bec
$ becd tx blog create-post cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug2 title2 body2 --chain-id bec
```

- Query posts:
```shell
$ becd q blog list-post
```

- Create comments for the first post (`slug1`)
```shell
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug1 body1-1 --chain-id bec 
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug1 body1-2 --chain-id bec 
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug1 body1-3 --chain-id bec 
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug1 body1-4 --chain-id bec 
```

- Query the comments
```shell
$ becd q blog list-comment slug1
```

- Create comments for the second post (`slug2`), the last one was duplicated from the last
```shell
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug2 body2-1 --chain-id bec 
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug2 body2-2 --chain-id bec 
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 slug2 body2-2 --chain-id bec 
```

- Query the comments. You should see only two comments
```shell
$ becd q blog list-comment slug2
```

- Try to create a comment for a invalid post slug
```shell
$ becd tx blog create-comment cosmos1ezptsm3npn54qx9vvpah4nymre59ykr9967vj9 invalidSlug bodyIn --chain-id bec 
```

- The post should not exist
```shell
$ becd q blog list-comment invalidSlug
```